### PR TITLE
Change default to default factory

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -48,8 +48,8 @@ async def health_check():
 
 @app.get("/transactions")
 async def get_transactions(
-    start_date: date = Query(default=date.today() - timedelta(days=30)),
-    end_date: date = Query(default=date.today()),
+    start_date: date = Query(default_factory=lambda: date.today() - timedelta(days=30)),
+    end_date: date = Query(default_factory=date.today),
     user_id: Optional[str] = None,
     transaction_type: Optional[str] = Query(None, alias="type", regex="^(owe|settle)$"),
 ):


### PR DESCRIPTION
This pull request updates the `get_transactions` endpoint in `api/main.py` to improve the handling of default values for query parameters.

Improvements to default value handling:

* [`api/main.py`](diffhunk://#diff-c2c3b0c64a2690193a471cfc8068fcb622a23e1b4323c693b6ba20835f26fb88L51-R52): Replaced `default` with `default_factory` for `start_date` and `end_date` query parameters in the `get_transactions` endpoint, ensuring that the default values are dynamically calculated at runtime.