### PR TITLE
Fixing set unicode preference

### DIFF
--- a/bot/commands/settings.py
+++ b/bot/commands/settings.py
@@ -114,7 +114,7 @@ async def handle_set_unicode_preference(interaction: discord.Interaction, use_un
         payload = set_unicode_preference_request.model_dump()
 
         # Send the request to the API
-        data = api_client.set_unicode_preference(payload)
+        data = api_client.set_unicode_preference(user_id, payload)
     except Exception as e:
         await handle_error(interaction, e, title="Error Updating Preference")
         return

--- a/bot/commands/settings.py
+++ b/bot/commands/settings.py
@@ -108,7 +108,6 @@ async def handle_set_unicode_preference(interaction: discord.Interaction, use_un
     # Call the external API to update the preference
     try:
         set_unicode_preference_request = SetUnicodePreferenceRequest(
-            user_id=user_id,
             use_unicode=use_unicode
         )
         payload = set_unicode_preference_request.model_dump()

--- a/models/set_unicode_preference_request.py
+++ b/models/set_unicode_preference_request.py
@@ -2,5 +2,4 @@ from pydantic import BaseModel
 
 class SetUnicodePreferenceRequest(BaseModel):
     """Request model for setting a user's Unicode preference."""
-    user_id: str
     use_unicode: bool

--- a/models/set_unicode_preference_request.py
+++ b/models/set_unicode_preference_request.py
@@ -2,4 +2,5 @@ from pydantic import BaseModel
 
 class SetUnicodePreferenceRequest(BaseModel):
     """Request model for setting a user's Unicode preference."""
+    user_id: str
     use_unicode: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,8 +137,11 @@ class FakeAPI:
         self.calls['settle_debt'] = payload
         return {'settled_amount': payload['amount'], 'remaining_amount': '0'}
 
-    def set_unicode_preference(self, payload):
-        self.calls['set_unicode_preference'] = payload
+    def set_unicode_preference(self, user_id, payload):
+        self.calls['set_unicode_preference'] = {
+            'user_id': user_id,
+            'use_unicode': payload['use_unicode']
+        }
         return {'message': 'Preference updated'}
 
 # -------------------------------


### PR DESCRIPTION
This pull request updates the `set_unicode_preference` functionality to include a `user_id` parameter, ensuring that Unicode preferences can be set for specific users. The changes span the request model, API client interactions, and test configurations.

### Changes related to `set_unicode_preference` functionality:

* **API Client Update**:
  - Modified the `set_unicode_preference` method in `bot/commands/settings.py` to include the `user_id` parameter when sending the request to the API.

* **Request Model Update**:
  - Added a `user_id` field to the `SetUnicodePreferenceRequest` model to support specifying the user for Unicode preference updates.

* **Test Configuration Update**:
  - Updated the `set_unicode_preference` method in `tests/conftest.py` to handle and verify the `user_id` parameter in test scenarios.