### PR TITLE
Updated timestamp format

### DIFF
--- a/models/transaction_entry.py
+++ b/models/transaction_entry.py
@@ -1,6 +1,6 @@
 from typing import Literal
 from fractions import Fraction
-from datetime import datetime
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field, field_validator
 
 class TransactionEntry(BaseModel):
@@ -10,7 +10,9 @@ class TransactionEntry(BaseModel):
     creditor: str
     amount: Fraction
     reason: str = ""
-    timestamp: str = Field(default_factory=lambda: datetime.now().isoformat(timespec="seconds"))
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+    )
 
     @field_validator("amount", mode="before")
     @classmethod


### PR DESCRIPTION
This pull request updates the `TransactionEntry` model in `models/transaction_entry.py` to improve timestamp handling by ensuring all timestamps are in UTC. The change also adjusts the default timestamp format to ISO 8601 with seconds precision.

Timestamp handling improvements:

* [`models/transaction_entry.py`](diffhunk://#diff-21cbfececce2b1a7e9cf41acc8b2cbe12dcb9b002178db8be0a7d3d628946d2dL3-R3): Imported `timezone` from the `datetime` module to support UTC timestamps.
* [`models/transaction_entry.py`](diffhunk://#diff-21cbfececce2b1a7e9cf41acc8b2cbe12dcb9b002178db8be0a7d3d628946d2dL13-R15): Updated the `timestamp` field's default factory to use `datetime.now(timezone.utc)` and format the timestamp as ISO 8601 in UTC (`'%Y-%m-%dT%H:%M:%SZ'`). This ensures consistent and precise timestamp formatting.