### PR TITLE
Added transaction log reasons for extra transactions and minor QOL ui enhancements

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -139,11 +139,11 @@ async def add_debt(request: OweRequest):
     save_debts(data)
 
     transaction_entry= TransactionEntry(
-        type="owe",
-        debtor= debtor_id,
-        creditor= creditor_id,
-        amount= amount,
-        reason= request.reason
+        type = "owe",
+        debtor = debtor_id,
+        creditor = creditor_id,
+        amount = amount,
+        reason = request.reason
     )
 
     # Append the transaction entry
@@ -278,10 +278,11 @@ async def settle_debt(request: SettleRequest):
     save_debts(data)
 
     transaction_entry= TransactionEntry(
-        type="settle",
-        debtor= debtor_id,
-        creditor= creditor_id,
-        amount= amount,
+        type = "settle",
+        debtor = debtor_id,
+        creditor = creditor_id,
+        amount = amount,
+        reason = request.reason
     )
 
     # Append the transaction entry
@@ -293,6 +294,8 @@ async def settle_debt(request: SettleRequest):
     return {
         "settled_amount": str(settled_amount),
         "remaining_amount": str(total_remaining_debt),
+        "reason": request.reason,
+        "timestamp": current_timestamp()
     }
 
 @app.get("/users/{user_id}/unicode_preference")

--- a/bot/api_client.py
+++ b/bot/api_client.py
@@ -49,3 +49,9 @@ def get_settings():
     response = requests.get(f"{config.API_URL}/settings")
     response.raise_for_status()
     return response.json()
+
+def get_transactions():
+    """Get the configuration values which have been set in the API."""
+    response = requests.get(f"{config.API_URL}/transactions")
+    response.raise_for_status()
+    return response.json()

--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -279,3 +279,4 @@ async def handle_debts_with_user(
     ),
         description="\n".join(lines)
     )
+    

--- a/bot/config.py
+++ b/bot/config.py
@@ -23,6 +23,13 @@ GET_ALL_DEBTS_COMMAND: str = "all_pints"
 DEBTS_WITH_USER_COMMAND: str = "pints_with_user"
 ROLL_COMMAND: str = "volcano"
 
+# Command Categories
+DEBT_DISPLAY_COMMAND_CATEGORY: str = "Debt Display"
+DEBT_TRANSACTIONS_COMMAND_CATEGORY: str = "Debt Transactions"
+SUPPORT_COMMAND_CATEGORY: str = "Support"
+SETTINGS_COMMAND_CATEGORY: str = "Settings"
+GAMES_COMMAND_CATEGORY: str = "Games"
+
 # Display
 USE_DECIMAL_OUTPUT: bool = False
 USE_TABLE_FORMAT_DEFAULT: bool = False

--- a/bot/setup/register_commands.py
+++ b/bot/setup/register_commands.py
@@ -18,35 +18,35 @@ def define_command_details() -> None:
         key="help",
         name="help",
         description="Get a list of available commands and their descriptions.",
-        category="Support"
+        category=config.SUPPORT_COMMAND_CATEGORY
     )
 
     Command(
         key="debts_with_user",
         name=config.DEBTS_WITH_USER_COMMAND,
         description=f"See current {config.CURRENCY_NAME} debts between yourself and another user.",
-        category="Debt Display"
+        category=config.DEBT_DISPLAY_COMMAND_CATEGORY
     )
 
     Command(
         key="get_debts",
         name=config.GET_DEBTS_COMMAND,
         description=f"See current {config.CURRENCY_NAME} debts for yourself or another user.",
-        category="Debt Display"
+        category=config.DEBT_DISPLAY_COMMAND_CATEGORY
     )
 
     Command(
         key="get_all_debts",
         name=config.GET_ALL_DEBTS_COMMAND,
         description=f"See everyone's total {config.CURRENCY_NAME} debts.",
-        category="Debt Display"
+        category=config.DEBT_DISPLAY_COMMAND_CATEGORY
     )
 
     Command(
         key="owe",
         name="owe",
         description=f"Add a number of {config.CURRENCY_NAME_PLURAL} you owe someone.",
-        category="Debt Transactions"
+        category=config.DEBT_TRANSACTIONS_COMMAND_CATEGORY
     )
 
     Command(
@@ -55,7 +55,7 @@ def define_command_details() -> None:
         description=(
             f"Settle {config.CURRENCY_NAME} debts you owe someone."
         ),
-        category="Debt Transactions"
+        category=config.DEBT_TRANSACTIONS_COMMAND_CATEGORY
     )
 
     Command(
@@ -64,28 +64,28 @@ def define_command_details() -> None:
         description=(
             f"Cashout your {config.CURRENCY_NAME} debts from someone."
         ),
-        category="Debt Transactions"
+        category=config.DEBT_TRANSACTIONS_COMMAND_CATEGORY
     )
 
     Command(
         key="set_unicode_preference",
         name="set_unicode_preference",
         description="Set your default preference for using Unicode fractions.",
-        category="Settings"
+        category=config.SETTINGS_COMMAND_CATEGORY
     )
 
     Command(
         key="settings",
         name="settings",
         description="View the current bot settings.",
-        category="Settings"
+        category=config.SETTINGS_COMMAND_CATEGORY
     )
 
     Command(
         key="roll",
         name=config.ROLL_COMMAND,
         description=f"Play {config.ROLL_COMMAND} game.",
-        category="Games"
+        category=config.GAMES_COMMAND_CATEGORY
     )
 
 def register_commands(bot):

--- a/bot/setup/register_commands.py
+++ b/bot/setup/register_commands.py
@@ -22,31 +22,31 @@ def define_command_details() -> None:
     )
 
     Command(
-        key="owe",
-        name="owe",
-        description=f"Add a number of {config.CURRENCY_NAME_PLURAL} you owe someone.",
-        category="Debts"
-    )
-
-    Command(
         key="debts_with_user",
         name=config.DEBTS_WITH_USER_COMMAND,
         description=f"See current {config.CURRENCY_NAME} debts between yourself and another user.",
-        category="Debts"
+        category="Debt Display"
     )
 
     Command(
         key="get_debts",
         name=config.GET_DEBTS_COMMAND,
         description=f"See current {config.CURRENCY_NAME} debts for yourself or another user.",
-        category="Debts"
+        category="Debt Display"
     )
 
     Command(
         key="get_all_debts",
         name=config.GET_ALL_DEBTS_COMMAND,
         description=f"See everyone's total {config.CURRENCY_NAME} debts.",
-        category="Debts"
+        category="Debt Display"
+    )
+
+    Command(
+        key="owe",
+        name="owe",
+        description=f"Add a number of {config.CURRENCY_NAME_PLURAL} you owe someone.",
+        category="Debt Transactions"
     )
 
     Command(
@@ -55,7 +55,7 @@ def define_command_details() -> None:
         description=(
             f"Settle {config.CURRENCY_NAME} debts you owe someone."
         ),
-        category="Debts"
+        category="Debt Transactions"
     )
 
     Command(
@@ -64,7 +64,7 @@ def define_command_details() -> None:
         description=(
             f"Cashout your {config.CURRENCY_NAME} debts from someone."
         ),
-        category="Debts"
+        category="Debt Transactions"
     )
 
     Command(
@@ -177,10 +177,10 @@ def register_commands(bot):
     @app_commands.describe(
         user="Who you want to settle debts with",
         amount=f"How many {config.CURRENCY_NAME_PLURAL} to settle",
-        message="Message to show with this transaction (optional)"
+        reason="Reason to show with this transaction (optional)"
     )
-    async def settle(interaction: discord.Interaction, user: discord.User, amount: str, message: str = ""):
-        await handle_settle(interaction, user, amount, message=message)
+    async def settle(interaction: discord.Interaction, user: discord.User, amount: str, reason: str = ""):
+        await handle_settle(interaction, user, amount, reason=reason)
 
     @bot.tree.command(
             name=Command.get("cashout").name,
@@ -189,10 +189,10 @@ def register_commands(bot):
     @app_commands.describe(
         user="Who you want to cashout debts from",
         amount=f"How many {config.CURRENCY_NAME_PLURAL} to cashout",
-        message="Message to show with this transaction (optional)"
+        reason="Reason to show with this transaction (optional)"
     )
-    async def cashout(interaction: discord.Interaction, user: discord.User, amount: str, message: str = ""):
-        await handle_cashout(interaction, user, amount, message=message)
+    async def cashout(interaction: discord.Interaction, user: discord.User, amount: str, reason: str = ""):
+        await handle_cashout(interaction, user, amount, reason=reason)
 
     @bot.tree.command(
         name=Command.get("set_unicode_preference").name,

--- a/models/settle_request.py
+++ b/models/settle_request.py
@@ -1,7 +1,11 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+import os
+
+MAXIMUM_DEBT_CHARACTER_LIMIT = int(os.environ.get("MAXIMUM_DEBT_CHARACTER_LIMIT", "200"))
 
 class SettleRequest(BaseModel):
     """Represents a request to settle a debt between two users."""
     debtor: int
     creditor: int
     amount: str
+    reason: str = Field(default="", max_length=MAXIMUM_DEBT_CHARACTER_LIMIT)  # Optional field with a max length of 200 characters

--- a/tests/test_debt_management.py
+++ b/tests/test_debt_management.py
@@ -57,10 +57,10 @@ class TestSettleCommand:
     async def test_settle_success_and_defer(self, bot, shared):
         interaction = DummyInteraction(DummyUser(1), bot)
         target = DummyUser(2)
-        await bot.tree.commands['settle'](interaction, target, '5')
+        await bot.tree.commands['settle'](interaction, target, '5', 'Test')
         assert interaction.response.deferred
         assert shared.fake_api.calls['settle_debt'] == {
-            'debtor': 1, 'creditor': 2, 'amount': '5'
+            'debtor': 1, 'creditor': 2, 'amount': '5', 'reason': 'Test'
         }
         calls = interaction.send_success_message_calls
         assert calls


### PR DESCRIPTION
- Patching /debts now takes in a reason like posting to it does
- Updated SettleModel for the above
- Transaction logs for /settle and /cashout now store the reason
- /owe now shows the new total debt after you owe a debt
- new command categorie split 'debt display' and 'debt transactions'
- refactor command categories to use bot config for names