### PR TITLE
Feature/pint emojis

### DIFF
--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -72,7 +72,7 @@ def find_net_difference(owed_to_you: Fraction,
     elif net_difference<0:
         return(f"\n__**NET DIFFERENCE - YOU OWE:**__ {net_difference_formatted}\nYou are in the negative!")
     else:
-        return(f"\nPerfectly balanced!")
+        return("\nPerfectly balanced!")
 
 
 async def handle_get_debts(interaction: discord.Interaction, 

--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -24,12 +24,8 @@ def format_individual_debt_entries(
     """Format debt entries for display."""
     lines = []
     total_amount = sum(Fraction(entry['amount']) for entry in entries)
-    total_formatted = currency_formatter(total_amount, use_unicode)
-    if show_conversion_currency:
-        total_formatted = with_conversion_currency(total_amount, total_formatted)
-    if show_emoji_visuals:
-        total_formatted = with_emoji_visuals(total_amount, total_formatted)
-    lines.append(total_formatted)
+
+    lines.append(format_overall_debts(total_amount,show_conversion_currency,show_emoji_visuals,use_unicode))
     
     if show_details:
         for entry in entries:
@@ -40,10 +36,8 @@ def format_individual_debt_entries(
                 amount = with_percentage(entry["amount"], total, amount)
             if show_emoji_visuals:
                 amount = with_emoji_visuals(entry["amount"], amount, False)
-            if entry['reason']!="":
-                lines.append(f"- {amount} for *{entry['reason']}* on {entry['timestamp']}")
-            else:
-                lines.append(f"- {amount} for *[No Reason Given]* on {entry['timestamp']}")
+            reason = entry['reason'] or "[No Reason Given]"
+            lines.append(f"- {amount} for *{reason}* on {entry['timestamp']}")
     return lines
 
 def format_overall_debts(

--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -27,6 +27,8 @@ def format_debt_entries(
     total_formatted = currency_formatter(total_amount, use_unicode)
     if show_conversion_currency:
         total_formatted = with_conversion_currency(total_amount, total_formatted)
+    if show_emoji_visuals:
+        total_formatted = with_emoji_visuals(total_amount, total_formatted)
     lines.append(total_formatted)
     
     if show_details:
@@ -47,11 +49,14 @@ def format_debt_entries(
 def find_net_difference(owed_to_you: Fraction,
         owed_by_you: Fraction,
         use_unicode: bool,
-        show_conversion_currency: bool) -> str:
+        show_conversion_currency: bool,
+        show_emoji_visuals: bool) -> str:
     net_difference = owed_to_you - owed_by_you
     net_difference_formatted = currency_formatter(abs(net_difference), use_unicode)
     if show_conversion_currency:
          net_difference_formatted = with_conversion_currency(net_difference, net_difference_formatted)
+    if show_emoji_visuals:
+         net_difference_formatted = with_emoji_visuals(net_difference, net_difference_formatted)
     
     if net_difference>0:
         return(f"\n__**NET DIFFERENCE - OWED TO YOU:**__ {net_difference_formatted}\nYou are in the positive!")

--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -12,7 +12,7 @@ def with_percentage(value: Fraction, total: Fraction, string_amount:str) -> str:
     formatted = f"{string_amount} {to_percentage(value, total, config.PERCENTAGE_DECIMAL_PLACES)}"
     return formatted
 
-def format_debt_entries(
+def format_individual_debt_entries(
     entries,
     total: Fraction,
     use_unicode: bool,
@@ -45,6 +45,21 @@ def format_debt_entries(
             else:
                 lines.append(f"- {amount} for *[No Reason Given]* on {entry['timestamp']}")
     return lines
+
+def format_overall_debts(
+        total_owed: Fraction,
+        show_conversion_currency: bool,
+        show_emoji_visuals: bool,
+        use_unicode: bool):
+    total_owed_formatted = currency_formatter(total_owed, use_unicode).upper()
+    if show_conversion_currency:
+        total_owed_formatted=with_conversion_currency(total_owed, total_owed)
+    if show_emoji_visuals:
+        total_owed_formatted=with_emoji_visuals(total_owed, total_owed_formatted)
+
+    return(
+        f"{total_owed_formatted}"
+    )
 
 def find_net_difference(owed_to_you: Fraction,
         owed_by_you: Fraction,
@@ -109,33 +124,22 @@ async def handle_get_debts(interaction: discord.Interaction,
     # Debts owed by the user
     if data["owed_by_you"]:
         total_owed_by_you = Fraction(data['total_owed_by_you'])
-        total_owed_by_you_formatted = currency_formatter(total_owed_by_you, use_unicode).upper()
-        if show_conversion_currency:
-            total_owed_by_you_formatted=with_conversion_currency(total_owed_by_you, total_owed_by_you_formatted)
-        if show_emoji_visuals:
-            total_owed_by_you_formatted=with_emoji_visuals(total_owed_by_you, total_owed_by_you_formatted)
-        
-        
-
-        lines.append(f"__**{config.CURRENCY_NAME_PLURAL} {'YOU' if user is None else 'THEY'} OWE:**__ {total_owed_by_you_formatted}")
+                
+        lines.append(f"__**{config.CURRENCY_NAME_PLURAL} {'YOU' if user is None else 'THEY'} OWE:**__ {format_overall_debts(total_owed_by_you,show_conversion_currency,show_emoji_visuals,use_unicode)}")
         for creditor_id, entries in data["owed_by_you"].items():
             creditor_name = await get_display_name(interaction.client, creditor_id)
-            entry_lines = format_debt_entries(entries, total_owed_by_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details)
+            entry_lines = format_individual_debt_entries(entries, total_owed_by_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details)
             lines.append(f"\n**{creditor_name}**: {entry_lines[0]}")
             lines.extend(entry_lines[1:])
 
     # Debts owed to the user
     if data["owed_to_you"]:
         total_owed_to_you = Fraction(data['total_owed_to_you'])
-        total_owed_to_you_formatted = currency_formatter(total_owed_to_you, use_unicode).upper()
-        if show_conversion_currency:
-            total_owed_to_you_formatted=with_conversion_currency(total_owed_to_you, total_owed_to_you_formatted)
-        if show_emoji_visuals:
-            total_owed_to_you_formatted=with_emoji_visuals(total_owed_to_you, total_owed_to_you_formatted)
-        lines.append(f"\n__**{config.CURRENCY_NAME_PLURAL} OWED TO {'YOU' if user is None else 'THEM'}:**__ {total_owed_to_you_formatted}")
+       
+        lines.append(f"\n__**{config.CURRENCY_NAME_PLURAL} OWED TO {'YOU' if user is None else 'THEM'}:**__ {format_overall_debts(total_owed_to_you,show_conversion_currency,show_emoji_visuals,use_unicode)}")
         for debtor_id, entries in data["owed_to_you"].items():
             debtor_name = await get_display_name(interaction.client, debtor_id)
-            entry_lines = format_debt_entries(entries, total_owed_to_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details)
+            entry_lines = format_individual_debt_entries(entries, total_owed_to_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details)
             lines.append(f"\n**{debtor_name}**: {entry_lines[0]}")
             lines.extend(entry_lines[1:])
 
@@ -220,16 +224,11 @@ async def handle_get_all_debts(
         default={"message": "The economy is in an unknown state"}
     )["message"]
 
-    total_formatted = currency_formatter(total_in_circulation, use_unicode)
-    if show_conversion_currency:
-        total_formatted=with_conversion_currency(total_in_circulation, total_formatted)
-    if show_emoji_visuals:
-        total_formatted=with_emoji_visuals(total_in_circulation, total_formatted)
     # Call send_table_message to send the data as a table
     await send_messages.send_two_column_table_message(
         interaction,
         title=f"{config.CURRENCY_NAME} Economy Overview",
-        description=f"{economy_health_message}\n\n__**Total {config.CURRENCY_NAME_PLURAL} in circulation: {total_formatted}**__",
+        description=f"{economy_health_message}\n\n__**Total {config.CURRENCY_NAME_PLURAL} in circulation: {format_overall_debts(total_in_circulation,show_conversion_currency,show_emoji_visuals,use_unicode)}**__",
         data=table_data,
         table_format=table_format
     )
@@ -284,34 +283,23 @@ async def handle_debts_with_user(
     # Debts owed by the user
     total_owed_by_you = Fraction(data['total_owed_by_you'])
     if data["owed_by_you"]:
-        total_owed_by_you_formatted = currency_formatter(total_owed_by_you, use_unicode).upper()
-        if show_conversion_currency:
-            total_owed_by_you_formatted=with_conversion_currency(total_owed_by_you, total_owed_by_you_formatted)
-        if show_emoji_visuals:
-            total_owed_by_you_formatted=with_emoji_visuals(total_owed_by_you, total_owed_by_you_formatted)
 
         lines.append(
             f"__**{config.CURRENCY_NAME_PLURAL} YOU OWE THEM:**__ "
-            f"{total_owed_by_you_formatted}"
+            f"{format_overall_debts(total_owed_by_you,show_conversion_currency,show_emoji_visuals,use_unicode)}"
         )
         if show_details:
-            lines.extend(format_debt_entries(data["owed_by_you"], total_owed_by_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details))
+            lines.extend(format_individual_debt_entries(data["owed_by_you"], total_owed_by_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details))
 
     total_owed_to_you = Fraction(data['total_owed_to_you'])
     # Debts owed to the user
     if data["owed_to_you"]:
-        total_owed_to_you_formatted = currency_formatter(total_owed_to_you, use_unicode).upper()
-        if show_conversion_currency:
-            total_owed_to_you_formatted=with_conversion_currency(total_owed_to_you, total_owed_to_you_formatted)
-        if show_emoji_visuals:
-            total_owed_to_you_formatted=with_emoji_visuals(total_owed_to_you, total_owed_to_you_formatted)
-
         lines.append(
             f"__**{config.CURRENCY_NAME_PLURAL} THEY OWE YOU:**__ "
-            f"{total_owed_to_you_formatted}"
+            f"{format_overall_debts(total_owed_to_you,show_conversion_currency,show_emoji_visuals,use_unicode)}"
         )
         if show_details:
-            lines.extend(format_debt_entries(data["owed_to_you"], total_owed_to_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details))
+            lines.extend(format_individual_debt_entries(data["owed_to_you"], total_owed_to_you, use_unicode, show_details, show_percentages, show_conversion_currency, show_emoji_visuals_on_details))
 
     # Net difference
     lines.append(find_net_difference(total_owed_to_you,
@@ -330,4 +318,3 @@ async def handle_debts_with_user(
     ),
         description="\n".join(lines)
     )
-    

--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -73,7 +73,6 @@ async def handle_get_debts(interaction: discord.Interaction,
                            show_conversion_currency: bool = None,
                            show_emoji_visuals: bool = None):
     """Handle fetching and displaying user debts for one user."""
-    table_format = config.USE_TABLE_FORMAT_DEFAULT if table_format is None else table_format
     show_percentages = config.SHOW_PERCENTAGES_DEFAULT if show_percentages is None else show_percentages
     show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT if show_conversion_currency is None else show_conversion_currency
     show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT if show_emoji_visuals is None else show_emoji_visuals
@@ -244,7 +243,6 @@ async def handle_debts_with_user(
     show_emoji_visuals: bool = None
 ):
     """Handle fetching and displaying user debts between two users."""
-    table_format = config.USE_TABLE_FORMAT_DEFAULT if table_format is None else table_format
     show_percentages = config.SHOW_PERCENTAGES_DEFAULT if show_percentages is None else show_percentages
     show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT if show_conversion_currency is None else show_conversion_currency
     show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT if show_emoji_visuals is None else show_emoji_visuals

--- a/bot/commands/debt_display.py
+++ b/bot/commands/debt_display.py
@@ -73,23 +73,12 @@ async def handle_get_debts(interaction: discord.Interaction,
                            show_conversion_currency: bool = None,
                            show_emoji_visuals: bool = None):
     """Handle fetching and displaying user debts for one user."""
-    if show_details is None:
-        show_details = config.SHOW_DETAILS_DEFAULT
-
-    if show_percentages is None:
-        show_percentages = config.SHOW_PERCENTAGES_DEFAULT
-
-    if show_conversion_currency is None:
-        show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT
-
-    if user is None:
-        user_id = str(interaction.user.id)
-    else:
-        user_id = str(user.id)
+    table_format = config.USE_TABLE_FORMAT_DEFAULT if table_format is None else table_format
+    show_percentages = config.SHOW_PERCENTAGES_DEFAULT if show_percentages is None else show_percentages
+    show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT if show_conversion_currency is None else show_conversion_currency
+    show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT if show_emoji_visuals is None else show_emoji_visuals
+    user_id = str(interaction.user.id) if user is None else str(user.id)
     
-    if show_emoji_visuals is None:
-        show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT
-
     # Defer the interaction to avoid timeout
     await interaction.response.defer()
     # Call the external API to fetch debts
@@ -169,22 +158,18 @@ async def handle_get_all_debts(
     show_emoji_visuals: bool = None
 ):
     """Handle fetching and displaying user debts for all users."""
-    if table_format is None:
-        table_format = config.USE_TABLE_FORMAT_DEFAULT
-    if show_percentages is None:
-        show_percentages = config.SHOW_PERCENTAGES_DEFAULT
-    if show_conversion_currency is None:
-        show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT
-    if show_emoji_visuals is None:
-        show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT
+    table_format = config.USE_TABLE_FORMAT_DEFAULT if table_format is None else table_format
+    show_percentages = config.SHOW_PERCENTAGES_DEFAULT if show_percentages is None else show_percentages
+    show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT if show_conversion_currency is None else show_conversion_currency
+    show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT if show_emoji_visuals is None else show_emoji_visuals
+
+    # Emoji visuals and table format are mutually exclusive
     if table_format:
-            show_emoji_visuals = False
+        show_emoji_visuals = False
     
     # Defer the interaction to avoid timeout
     await interaction.response.defer()
 
-    if table_format and show_emoji_visuals:
-        await send_messages
     # Call the external API to fetch all debts
     try:
         data = api_client.get_all_debts()
@@ -259,17 +244,10 @@ async def handle_debts_with_user(
     show_emoji_visuals: bool = None
 ):
     """Handle fetching and displaying user debts between two users."""
-    if show_details is None:
-        show_details = config.SHOW_DETAILS_DEFAULT
-
-    if show_percentages is None:
-        show_percentages = config.SHOW_PERCENTAGES_DEFAULT
-
-    if show_conversion_currency is None:
-        show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT
-
-    if show_emoji_visuals is None:
-        show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT
+    table_format = config.USE_TABLE_FORMAT_DEFAULT if table_format is None else table_format
+    show_percentages = config.SHOW_PERCENTAGES_DEFAULT if show_percentages is None else show_percentages
+    show_conversion_currency = config.SHOW_CONVERSION_CURRENCY_DEFAULT if show_conversion_currency is None else show_conversion_currency
+    show_emoji_visuals = config.SHOW_EMOJI_VISUALS_DEFAULT if show_emoji_visuals is None else show_emoji_visuals
 
     user_id1 = str(interaction.user.id)
     user_id2 = str(user.id)
@@ -341,7 +319,8 @@ async def handle_debts_with_user(
     lines.append(find_net_difference(total_owed_to_you,
                                      total_owed_by_you,
                                      use_unicode,
-                                     show_conversion_currency))
+                                     show_conversion_currency,
+                                     show_emoji_visuals))
 
     # Send the formatted response
     await send_messages.send_info_message(

--- a/bot/commands/support.py
+++ b/bot/commands/support.py
@@ -19,12 +19,12 @@ async def handle_help_command(interaction: discord.Interaction):
     for category, commands in categorised_commands.items():
 
         # Add a header for each category
-        help_message += f"\n**{category}:**\n"
+        help_message += f"\n__**{category}:**__\n"
         for command in commands:
             # Add the command name and description to the help message
             help_message += f"**/{command.name}** — {command.description}\n"
 
-    help_message += f"\n__**What can you redeem each {config.CURRENCY_NAME} for?**__\n"
+    help_message += f"\n\n__**What can you redeem each {config.CURRENCY_NAME} for?**__\n"
     for item in config.TRANSFERABLE_ITEMS:
         help_message += f"- {item}\n"
 

--- a/bot/config.py
+++ b/bot/config.py
@@ -38,6 +38,7 @@ PERCENTAGE_DECIMAL_PLACES: int = 1
 SHOW_DETAILS_DEFAULT: bool = False
 SORT_OWES_FIRST: bool = True
 SHOW_EMOJI_VISUALS_DEFAULT: bool = False
+SHOW_EMOJI_VISUALS_ON_DETAILS_DEFAULT: bool = True
 CURRENCY_DISPLAY_EMOJI: str = "🍺"
 
 # Display - Conversion Currency

--- a/bot/config.py
+++ b/bot/config.py
@@ -37,6 +37,8 @@ SHOW_PERCENTAGES_DEFAULT: bool = False
 PERCENTAGE_DECIMAL_PLACES: int = 1
 SHOW_DETAILS_DEFAULT: bool = False
 SORT_OWES_FIRST: bool = True
+SHOW_EMOJI_VISUALS_DEFAULT: bool = False
+CURRENCY_DISPLAY_EMOJI: str = "🍺"
 
 # Display - Conversion Currency
 CONVERSION_CURRENCY: str = "£"

--- a/bot/setup/register_commands.py
+++ b/bot/setup/register_commands.py
@@ -119,13 +119,22 @@ def register_commands(bot):
         user="Another user to view debts for",
         show_details=f"Show details of each individual debt (Default:{config.SHOW_DETAILS_DEFAULT})",
         show_percentages=f"Display percentages of how much of the economy each person owes/is owed (Default: {config.SHOW_PERCENTAGES_DEFAULT})",
-         show_conversion_currency=(
+        show_conversion_currency=(
             f"Show the equivalent value of the debts in {config.CONVERSION_CURRENCY} "
             f"(Default: {config.SHOW_CONVERSION_CURRENCY_DEFAULT})"
+        ),
+        show_emoji_visuals=(
+                f"Visualise the worth of the debts with {config.CURRENCY_DISPLAY_EMOJI} emojis "
+                f"(Default: {config.SHOW_EMOJI_VISUALS_DEFAULT})"
         )
     )
-    async def get_debts(interaction: discord.Interaction, user: discord.User = None, show_details: bool = None, show_percentages: bool = None, show_conversion_currency: bool = None):
-        await handle_get_debts(interaction, user, show_details, show_percentages, show_conversion_currency)
+    async def get_debts(interaction: discord.Interaction, 
+                        user: discord.User = None, 
+                        show_details: bool = None, 
+                        show_percentages: bool = None, 
+                        show_conversion_currency: bool = None, 
+                        show_emoji_visuals: bool = None):
+        await handle_get_debts(interaction, user, show_details, show_percentages, show_conversion_currency, show_emoji_visuals)
 
     @bot.tree.command(
         name=Command.get("get_all_debts").name,
@@ -133,14 +142,21 @@ def register_commands(bot):
     )
     @app_commands.describe(
         table_format=f"Display in table format (not recommended for mobile, Default: {config.USE_TABLE_FORMAT_DEFAULT}).",
-        show_percentages=f"Display percentages of how much of the economy each person owes/is owed (Default: {config.SHOW_PERCENTAGES_DEFAULT})",
+        show_percentages=(
+            "Display percentages of how much of the economy each person owes/is owed "
+            f"(Default: {config.SHOW_PERCENTAGES_DEFAULT})"
+        ),
         show_conversion_currency=(
                 f"Show the worth of the debts in {config.CONVERSION_CURRENCY} "
                 f"(Default: {config.SHOW_CONVERSION_CURRENCY_DEFAULT})"
+            ),
+        show_emoji_visuals=(
+                f"Visualise the worth of the debts with {config.CURRENCY_DISPLAY_EMOJI} emojis "
+                f"(Default: {config.SHOW_EMOJI_VISUALS_DEFAULT})"
             )
     )
-    async def get_all_debts(interaction: discord.Interaction, table_format: bool = None, show_percentages: bool = None, show_conversion_currency: bool = None):
-        await handle_get_all_debts(interaction, table_format, show_percentages, show_conversion_currency)
+    async def get_all_debts(interaction: discord.Interaction, table_format: bool = None, show_percentages: bool = None, show_conversion_currency: bool = None, show_emoji_visuals: bool = None):
+        await handle_get_all_debts(interaction, table_format, show_percentages, show_conversion_currency, show_emoji_visuals)
 
     @bot.tree.command(
         name=Command.get("debts_with_user").name,
@@ -159,6 +175,10 @@ def register_commands(bot):
         show_conversion_currency=(
             f"Show the worth of the debts in {config.CONVERSION_CURRENCY} "
             f"(Default: {config.SHOW_CONVERSION_CURRENCY_DEFAULT})"
+        ),
+        show_emoji_visuals=(
+                f"Visualise the worth of the debts with {config.CURRENCY_DISPLAY_EMOJI} emojis "
+                f"(Default: {config.SHOW_EMOJI_VISUALS_DEFAULT})"
         )
     )
     async def debts_with_user(
@@ -166,9 +186,10 @@ def register_commands(bot):
         user: discord.User,
         show_details: bool = None,
         show_percentages: bool = None,
-        show_conversion_currency: bool = None
+        show_conversion_currency: bool = None,
+        show_emoji_visuals: bool = None
     ):
-        await handle_debts_with_user(interaction, user, show_details, show_percentages, show_conversion_currency)
+        await handle_debts_with_user(interaction, user, show_details, show_percentages, show_conversion_currency, show_emoji_visuals)
 
     @bot.tree.command(
         name=Command.get("settle").name,

--- a/bot/utilities/formatter.py
+++ b/bot/utilities/formatter.py
@@ -66,10 +66,10 @@ def with_conversion_currency(value, string_amount) -> str:
         formatted = f"{string_amount} [{converted}{config.CONVERSION_CURRENCY}]"
     return formatted
 
-def with_emoji_visuals(value, string_amount) -> str:
+def with_emoji_visuals(value, string_amount, new_line = True) -> str:
     value = round(Fraction(value))
     emojis = config.CURRENCY_DISPLAY_EMOJI*value
-    formatted = f"{string_amount}\n{emojis}"
+    formatted = f"{string_amount}{"\n" if new_line else ""}{emojis}"
     return formatted
 
 def currency_formatter(amount, use_unicode: bool=False) -> str:

--- a/bot/utilities/formatter.py
+++ b/bot/utilities/formatter.py
@@ -66,6 +66,12 @@ def with_conversion_currency(value, string_amount) -> str:
         formatted = f"{string_amount} [{converted}{config.CONVERSION_CURRENCY}]"
     return formatted
 
+def with_emoji_visuals(value, string_amount) -> str:
+    value = round(Fraction(value))
+    emojis = config.CURRENCY_DISPLAY_EMOJI*value
+    formatted = f"{string_amount}\n{emojis}"
+    return formatted
+
 def currency_formatter(amount, use_unicode: bool=False) -> str:
     """Format the currency amount based on the configuration."""
     fraction = Fraction(amount)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,8 @@ PATCHED_CONFIG = {
     "TRANSFERABLE_ITEMS": ["Beer", "Wine"],
     "SHOW_PERCENTAGES_DEFAULT": False,
     "USE_TABLE_FORMAT_DEFAULT": True,
+    "SHOW_EMOJI_VISUALS_DEFAULT": False,
+    "CURRENCY_DISPLAY_EMOJI": "🍺",
     "ECONOMY_HEALTH_MESSAGES": [
         {"threshold": 1, "message": "Economy active"},
         {"threshold": 0, "message": "Economy is dead"}


### PR DESCRIPTION
- New feature for showing emojis for debt amounts

3 new config settings 
- SHOW_EMOJI_VISUALS_DEFAULT (Default: False)
- SHOW_EMOJI_VISUALS_ON_DETAILS_DEFAULT (Default: True)
- CURRENCY_DISPLAY_EMOJI (Default: "🍺:)

- Minor messaging formatting fixes
- debts_with_user now shows net amount owed between users
- emojis won't go on a new line for details