### PR TITLE
Feature/message fixer

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -10,6 +10,10 @@ import bot.configuration.constants as constants
 API_URL: str = os.getenv("API_URL", "http://api:8000")
 API_TIMEOUT: int = 10
 
+# Discord Constants
+DISCORD_EMBED_TITLE_LIMIT = 256
+DISCORD_EMBED_DESCRIPTION_LIMIT = 4096
+
 # Misc
 RANDOM_NUMBER_GENERATOR = SystemRandom()
 
@@ -43,7 +47,7 @@ SHOW_EMOJI_VISUALS_ON_DETAILS_DEFAULT: bool = True
 CURRENCY_DISPLAY_EMOJI: str = "🍺"
 DATE_FORMAT: str = "%d-%m-%Y" #add %A for day of the week
 TIME_FORMAT: str = "%H:%M" #24 hour time, use "%I:%M %p" instead for 12 hour time"
-DISPLAY_TRANSACTIONS_AS_SETTLE_DEFAULT: bool = True #if false, will display as 'cashout' instead
+DISPLAY_TRANSACTIONS_AS_SETTLE_DEFAULT: bool = False #if false, will display as 'cashout' instead
 
 # Display - Conversion Currency
 CONVERSION_CURRENCY: str = "£"

--- a/bot/utilities/send_messages.py
+++ b/bot/utilities/send_messages.py
@@ -103,7 +103,7 @@ async def send_message(
         await send_error_message(
             interaction,
             "Formatting Error",
-            "Title exceeds Discord's 256 character limit. Sorry about that"
+            f"Title exceeds Discord's {config.DISCORD_EMBED_TITLE_LIMIT} character limit. Sorry about that"
         )
         return
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,8 @@ PATCHED_CONFIG = {
     "QUANTIZE_SETTLING_DEBTS": True,
     "SHOW_DETAILS_DEFAULT": True,
     "EXCHANGE_RATE_TO_CONVERSION_CURRENCY": 6,
-    "DATE_FORMAT": "%d-%m-%Y"
+    "DATE_FORMAT": "%d-%m-%Y",
+    "DISPLAY_TRANSACTIONS_AS_SETTLE_DEFAULT": False
 }
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_debt_display.py
+++ b/tests/test_debt_display.py
@@ -241,4 +241,4 @@ class TestTransactionsCommand:
         assert "Lunch" in description
         assert "Repayment" in description
         assert "Total Owed In Period" in description
-        assert "Total Settled In Period" in description
+        assert "Total Cashed Out In Period" in description


### PR DESCRIPTION
- new global paginator will split discord messages into multiple messages if they are too long
- will split on a "\n" if possible
- config constants for discord message limits
- display transactions as "cashout" by default instead of "settle"